### PR TITLE
'aux' is a reserved word in Windows. 'aux' directory renamed to 'misc'

### DIFF
--- a/FILE_STATUS
+++ b/FILE_STATUS
@@ -10,11 +10,11 @@
 ./qcr/widgets/tables.h&cpp
 ./qcr/widgets/views.h&cpp                 ok
 ./core/def/idiomatic_for.h                TODO get rid of
-./core/aux/angles.h&cpp                   simple and good, has tests (003)
-./core/aux/async.h&cpp                    simple and good
-./core/aux/exception.h&cpp                simple and good
-./core/aux/settings.h&cpp                 simple and good, need unclear
-./core/aux/variant.h&cpp                  need unclear, revise along with meta pars
+./core/misc/angles.h&cpp                   simple and good, has tests (003)
+./core/misc/async.h&cpp                    simple and good
+./core/misc/exception.h&cpp                simple and good
+./core/misc/settings.h&cpp                 simple and good, need unclear
+./core/misc/variant.h&cpp                  need unclear, revise along with meta pars
 ./core/typ/bool_vector.h&cpp              simple and good
 ./core/typ/cached.h (only)                work in progress TODO needs tests
 ./core/typ/curve.h&cpp                    ok, may need SubCurve for speed

--- a/core/calc/active_clusters.cpp
+++ b/core/calc/active_clusters.cpp
@@ -14,7 +14,7 @@
 
 #include "core/calc/active_clusters.h"
 #include "core/data/collect_intensities.h"
-#include "core/aux/async.h"
+#include "core/misc/async.h"
 #include "core/data/lens.h"
 #include "core/session.h"
 //#include "qcr/base/debug.h"

--- a/core/calc/all_infos.cpp
+++ b/core/calc/all_infos.cpp
@@ -13,7 +13,7 @@
 //  ***********************************************************************************************
 
 #include "core/calc/all_infos.h"
-#include "core/aux/async.h"
+#include "core/misc/async.h"
 #include "core/calc/coord_trafos.h"
 #include "core/calc/interpolate_polefig.h"
 #include "core/fit/peak_function.h"

--- a/core/calc/coord_trafos.h
+++ b/core/calc/coord_trafos.h
@@ -15,7 +15,7 @@
 #ifndef COORD_TRAFOS_H
 #define COORD_TRAFOS_H
 
-#include "core/aux/angles.h" // no auto rm
+#include "core/misc/angles.h" // no auto rm
 
 namespace algo {
 

--- a/core/calc/interpolate_polefig.cpp
+++ b/core/calc/interpolate_polefig.cpp
@@ -14,7 +14,7 @@
 
 #include "core/calc/interpolate_polefig.h"
 #include "core/session.h"
-#include "core/aux/async.h"
+#include "core/misc/async.h"
 #include "qcr/base/debug.h" // ASSERT
 #include <qmath.h>
 

--- a/core/data/angle_map.h
+++ b/core/data/angle_map.h
@@ -15,7 +15,7 @@
 #ifndef ANGLE_MAP_H
 #define ANGLE_MAP_H
 
-#include "core/aux/angles.h"
+#include "core/misc/angles.h"
 #include "core/typ/range.h"
 #include "core/typ/size2d.h"
 #include <QSharedPointer> // no auto rm

--- a/core/loaders/fastyamlloader.cpp
+++ b/core/loaders/fastyamlloader.cpp
@@ -13,7 +13,7 @@
 //  ***********************************************************************************************
 
 #include "core/loaders/fastyamlloader.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include <sstream>
 
 // Allows for a very verbious yaml parser for debugging purposes:

--- a/core/loaders/load_caress.cpp
+++ b/core/loaders/load_caress.cpp
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/raw/rawfile.h"
 #include <qmath.h>
 #include <sstream>

--- a/core/loaders/load_mar.cpp
+++ b/core/loaders/load_mar.cpp
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/raw/rawfile.h"
 #include "3rdparty/Mar/MarReader.h"
 

--- a/core/loaders/load_tiff.cpp
+++ b/core/loaders/load_tiff.cpp
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/raw/rawfile.h"
 #include <QDataStream>
 #include <QDir>

--- a/core/loaders/load_yaml.cpp
+++ b/core/loaders/load_yaml.cpp
@@ -13,7 +13,7 @@
 //  ***********************************************************************************************
 
 #include "core/loaders/fastyamlloader.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "qcr/base/debug.h"
 #include <functional>
 

--- a/core/loaders/loaders.cpp
+++ b/core/loaders/loaders.cpp
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/raw/rawfile.h"
 #include <QStringBuilder> // for ".." % ..
 

--- a/core/misc/angles.cpp
+++ b/core/misc/angles.cpp
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/angles.cpp
+//! @file      core/misc/angles.cpp
 //! @brief     Implements  classes deg and rad.
 //!
 //! @homepage  https://github.com/scgmlz/Steca
@@ -14,7 +14,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/angles.h"
+#include "core/misc/angles.h"
 #include <qmath.h>
 
 deg::deg(rad r)

--- a/core/misc/angles.h
+++ b/core/misc/angles.h
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/angles.h
+//! @file      core/misc/angles.h
 //! @brief     Defines classes deg and rad.
 //!
 //! @homepage  https://github.com/scgmlz/Steca

--- a/core/misc/async.cpp
+++ b/core/misc/async.cpp
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/async.cpp
+//! @file      core/misc/async.cpp
 //! @brief     Implements class TakesLongTime
 //!
 //! @homepage  https://github.com/scgmlz/Steca
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/async.h"
+#include "core/misc/async.h"
 #include "qcr/base/debug.h"
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QProgressBar>

--- a/core/misc/async.h
+++ b/core/misc/async.h
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/async.h
+//! @file      core/misc/async.h
 //! @brief     Defines class TakesLongTime
 //!
 //! @homepage  https://github.com/scgmlz/Steca

--- a/core/misc/exception.cpp
+++ b/core/misc/exception.cpp
@@ -2,8 +2,8 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/variant.h
-//! @brief     Defines helper functions related to QVariant
+//! @file      core/misc/exception.cpp
+//! @brief     Implements class Exception
 //!
 //! @homepage  https://github.com/scgmlz/Steca
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -12,19 +12,11 @@
 //
 //  ***********************************************************************************************
 
-#ifndef VARIANT_H
-#define VARIANT_H
+#include "core/misc/exception.h"
+#include "qcr/base/debug.h"
 
-#include <QVariant>
-
-bool isNumeric(const QVariant&);
-
-// The usual comparators: <0, 0, >0
-typedef int VariantComparator(const QVariant&, const QVariant&);
-
-int cmp_int(const QVariant&, const QVariant&);
-int cmp_str(const QVariant&, const QVariant&);
-int cmp_real(const QVariant&, const QVariant&);
-int cmp_date(const QVariant&, const QVariant&);
-
-#endif // VARIANT_H
+Exception::Exception(const QString& msg) noexcept
+    : msg_(msg)
+{
+    qWarning() << "Exception: " << msg;
+}

--- a/core/misc/exception.h
+++ b/core/misc/exception.h
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/exception.h
+//! @file      core/misc/exception.h
 //! @brief     Defines class Exception
 //!
 //! @homepage  https://github.com/scgmlz/Steca

--- a/core/misc/settings.cpp
+++ b/core/misc/settings.cpp
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/settings.cpp
+//! @file      core/misc/settings.cpp
 //! @brief     Implements class XSettings
 //!
 //! @homepage  https://github.com/scgmlz/Steca
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/settings.h"
+#include "core/misc/settings.h"
 //#include "qcr/base/debug.h"
 
 XSettings::XSettings(const QString& group)

--- a/core/misc/settings.h
+++ b/core/misc/settings.h
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/settings.h
+//! @file      core/misc/settings.h
 //! @brief     Defines class XSettings
 //!
 //! @homepage  https://github.com/scgmlz/Steca

--- a/core/misc/variant.cpp
+++ b/core/misc/variant.cpp
@@ -2,7 +2,7 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/variant.cpp
+//! @file      core/misc/variant.cpp
 //! @brief     Implements helper functions related to QVariant
 //!
 //! @homepage  https://github.com/scgmlz/Steca
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/variant.h"
+#include "core/misc/variant.h"
 #include <QDate>
 
 bool isNumeric(const QVariant& v)

--- a/core/misc/variant.h
+++ b/core/misc/variant.h
@@ -2,8 +2,8 @@
 //
 //  Steca: stress and texture calculator
 //
-//! @file      core/aux/exception.cpp
-//! @brief     Implements class Exception
+//! @file      core/misc/variant.h
+//! @brief     Defines helper functions related to QVariant
 //!
 //! @homepage  https://github.com/scgmlz/Steca
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -12,11 +12,19 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/exception.h"
-#include "qcr/base/debug.h"
+#ifndef VARIANT_H
+#define VARIANT_H
 
-Exception::Exception(const QString& msg) noexcept
-    : msg_(msg)
-{
-    qWarning() << "Exception: " << msg;
-}
+#include <QVariant>
+
+bool isNumeric(const QVariant&);
+
+// The usual comparators: <0, 0, >0
+typedef int VariantComparator(const QVariant&, const QVariant&);
+
+int cmp_int(const QVariant&, const QVariant&);
+int cmp_str(const QVariant&, const QVariant&);
+int cmp_real(const QVariant&, const QVariant&);
+int cmp_date(const QVariant&, const QVariant&);
+
+#endif // VARIANT_H

--- a/core/pars/detector.cpp
+++ b/core/pars/detector.cpp
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/settings.h"
+#include "core/misc/settings.h"
 #include "core/session.h"
 //#include "qcr/base/debug.h"
 

--- a/core/pars/interpol_params.cpp
+++ b/core/pars/interpol_params.cpp
@@ -13,7 +13,7 @@
 //  ***********************************************************************************************
 
 #include "core/pars/interpol_params.h"
-#include "core/aux/settings.h"
+#include "core/misc/settings.h"
 #include "core/session.h"
 
 InterpolParams::InterpolParams()

--- a/core/raw/image.cpp
+++ b/core/raw/image.cpp
@@ -13,7 +13,7 @@
 //  ***********************************************************************************************
 
 #include "core/raw/image.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "qcr/base/debug.h"
 
 Image::Image(const size2d& size, float val)

--- a/core/raw/metadata.h
+++ b/core/raw/metadata.h
@@ -15,8 +15,8 @@
 #ifndef METADATA_H
 #define METADATA_H
 
-#include "core/aux/angles.h"
-#include "core/aux/variant.h"
+#include "core/misc/angles.h"
+#include "core/misc/variant.h"
 
 //! The meta data associated with one Measurement.
 

--- a/core/raw/rawfile.cpp
+++ b/core/raw/rawfile.cpp
@@ -12,7 +12,7 @@
 //
 //  ***********************************************************************************************
 
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/raw/rawfile.h"
 #include "qcr/base/debug.h"
 #include <QStringBuilder> // for ".." % ..

--- a/core/session.cpp
+++ b/core/session.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #include "core/session.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "qcr/base/debug.h" // ASSERT
 #include <QJsonDocument>
 

--- a/core/typ/json.cpp
+++ b/core/typ/json.cpp
@@ -13,7 +13,7 @@
 //  ***********************************************************************************************
 
 #include "core/typ/json.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/typ/range.h"
 #include <QStringList> // needed under Travis
 

--- a/core/typ/range.cpp
+++ b/core/typ/range.cpp
@@ -15,7 +15,7 @@
 //  ***********************************************************************************************
 
 #include "core/typ/range.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "core/typ/json.h"
 #include "qcr/base/debug.h"
 

--- a/gui/dialogs/export_dfgram.cpp
+++ b/gui/dialogs/export_dfgram.cpp
@@ -13,8 +13,8 @@
 //  ***********************************************************************************************
 
 #include "gui/dialogs/export_dfgram.h"
-#include "core/aux/async.h"
-#include "core/aux/exception.h"
+#include "core/misc/async.h"
+#include "core/misc/exception.h"
 #include "core/session.h"
 #include "gui/dialogs/subdialog_file.h"
 #include "gui/dialogs/file_dialog.h"

--- a/gui/dialogs/export_polefig.cpp
+++ b/gui/dialogs/export_polefig.cpp
@@ -13,10 +13,10 @@
 //  ***********************************************************************************************
 
 #include "gui/dialogs/export_polefig.h"
-#include "core/aux/async.h"
+#include "core/misc/async.h"
 #include "core/data/collect_intensities.h"
 #include "core/session.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "gui/dialogs/subdialog_file.h"
 #include "gui/dialogs/file_dialog.h"
 #include "gui/mainwin.h"

--- a/gui/dialogs/io_session.cpp
+++ b/gui/dialogs/io_session.cpp
@@ -14,8 +14,8 @@
 
 #include "gui/dialogs/io_session.h"
 #include "core/session.h"
-#include "core/aux/async.h"
-#include "core/aux/exception.h"
+#include "core/misc/async.h"
+#include "core/misc/exception.h"
 #include "gui/dialogs/file_dialog.h"
 #include "qcr/base/debug.h" // warning
 #include <QDir>

--- a/gui/dialogs/load_data.cpp
+++ b/gui/dialogs/load_data.cpp
@@ -14,8 +14,8 @@
 
 #include "gui/dialogs/load_data.h"
 #include "core/session.h"
-#include "core/aux/async.h"
-#include "core/aux/exception.h"
+#include "core/misc/async.h"
+#include "core/misc/exception.h"
 #include "gui/dialogs/file_dialog.h"
 #include "qcr/base/debug.h" // warning
 #include <QDir>

--- a/gui/mainwin.cpp
+++ b/gui/mainwin.cpp
@@ -13,8 +13,8 @@
 //  ***********************************************************************************************
 
 #include "gui/mainwin.h"
-#include "core/aux/async.h"
-#include "core/aux/settings.h"
+#include "core/misc/async.h"
+#include "core/misc/settings.h"
 #include "core/session.h"
 #include "gui/actions/image_trafo_actions.h"
 #include "gui/actions/menus.h"

--- a/gui/view/bigtable.h
+++ b/gui/view/bigtable.h
@@ -15,7 +15,7 @@
 #ifndef BIGTABLE_H
 #define BIGTABLE_H
 
-#include "core/aux/variant.h"
+#include "core/misc/variant.h"
 #include "qcr/widgets/tables.h"
 
 //! Model for the BigtableView view.

--- a/gui/view/plot_polefig.cpp
+++ b/gui/view/plot_polefig.cpp
@@ -14,7 +14,7 @@
 
 #include "gui/view/plot_polefig.h"
 #include "core/session.h"
-#include "core/aux/angles.h"
+#include "core/misc/angles.h"
 //#include "qcr/base/debug.h"
 #include "QCustomPlot/qcustomplot.h"
 

--- a/utest/test003_angles.cpp
+++ b/utest/test003_angles.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "core/aux/angles.h"
+#include "core/misc/angles.h"
 #include <qmath.h>
 
 TEST(Angles, Conversion) {

--- a/utest/test007_variant.cpp
+++ b/utest/test007_variant.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include "core/aux/variant.h"
+#include "core/misc/variant.h"
 
 TEST(Variant, Comparison) {
     QVariant v1(1), v2(2);

--- a/utest/test010_io.cpp
+++ b/utest/test010_io.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 #include "core/loaders/loaders.h"
 #include "core/session.h"
-#include "core/aux/exception.h"
+#include "core/misc/exception.h"
 #include "testdata.h"
 
 TEST(IO, Caress) {


### PR DESCRIPTION
If correctly handled by Appveyor, this pull request should solve the problem with the aux folder.